### PR TITLE
Get flask session secret from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Each parameter can be passed either in CLI as an argument or as a environment va
 | samlproviderid | SAML_PROVIDER_ID | ID of the Identity Provider                                                               |                           |
 | samlloginurl   | SAML_LOGIN_URL   | Login url of the Identity Provider                                                        |                           |
 | samlcert       | SAML_CERT        | Certificate of the IdP                                                                    |                           |
+| secretkey      | SECRET_KEY       | Flask session secret key                                                                  | os.urandom(16)            |
 
 
 <br>

--- a/bridges/app.py
+++ b/bridges/app.py
@@ -40,7 +40,7 @@ app = Flask(__name__)
 
 # In order to use session in flask we need to
 # set the secret key to encrypt cookies
-app.config['SECRET_KEY'] = os.urandom(16)
+app.config['SECRET_KEY'] = args.session_secret_key
 
 # Swagger has problems with proxy, so we need to add this magic line to
 # make it work with k8s service

--- a/bridges/argument_parser.py
+++ b/bridges/argument_parser.py
@@ -1,5 +1,6 @@
 import argparse
 import configargparse
+import os
 from dotenv import load_dotenv
 
 
@@ -8,6 +9,16 @@ load_dotenv()
 
 
 parser = configargparse.ArgumentParser(description='Building bridges')
+
+# App arguments
+parser.add_argument(
+    '--secretkey',
+    type=str,
+    default=os.urandom(16),
+    dest='session_secret_key',
+    env_var="SECRET_KEY",
+    help='Flask session secret key'
+)
 
 # Database arguments
 parser.add_argument(


### PR DESCRIPTION
When multiple pods were created for building bridges instance, they all had different secret key - this means that cookies weren't encrypted with the same key, so session wouldn't work. Now we get secret key from args/env, so we can set the same secret key to all the pods.